### PR TITLE
add method for webhook aplication, transaction line items and transaction refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,18 +148,20 @@ the names of resources _should_ match what's in thdis package.
 | [Report Runs](https://stripe.com/docs/api/reporting/report_type) | `stripeReportingReportRunId()` | `frr_jJ9LNixW3dEQco0XTeX2zE1R` |
 
 ### Financial Connections
-| API Resource                                                                     | Method                                           | Example ID                         |
-|----------------------------------------------------------------------------------|--------------------------------------------------|------------------------------------|
-| [Accounts](https://stripe.com/docs/api/financial_connections/accounts)           | `stripeFinancialConnectionAccountId()`           | `fca_z3JzQ1OCkYved5uWOqh3b387`     |
-| [Account Ownership](https://stripe.com/docs/api/financial_connections/ownership) | `stripeFinancialConnectionsAccountOwnershipId()` | `fcaowns_XwyWHMQFo9koh9U1TuOMW43D` |
-| [Sessions](https://stripe.com/docs/api/financial_connections/session)            | `stripeFinancialConnectionsSessionId()`          | `fcsess_ZnomHexUQ68qiad2GWqQsvsa`  |
-| [Transactions](https://stripe.com/docs/api/financial_connections/transaction)    | `stripeFinancialConnectionTransactionId()`       | `fctxn_yIcXfBzg3NSJRYHqIW5spz4v`   |
+| API Resource                                                                         | Method                                            | Example ID                          |
+|--------------------------------------------------------------------------------------|---------------------------------------------------|-------------------------------------|
+| [Accounts](https://stripe.com/docs/api/financial_connections/accounts)               | `stripeFinancialConnectionAccountId()`            | `fca_z3JzQ1OCkYved5uWOqh3b387`      |
+| [Account Ownership](https://stripe.com/docs/api/financial_connections/ownership)     | `stripeFinancialConnectionsAccountOwnershipId()`  | `fcaowns_XwyWHMQFo9koh9U1TuOMW43D`  |
+| [Sessions](https://stripe.com/docs/api/financial_connections/session)                | `stripeFinancialConnectionsSessionId()`           | `fcsess_ZnomHexUQ68qiad2GWqQsvsa`   |
+| [Transactions](https://stripe.com/docs/api/financial_connections/transaction)        | `stripeFinancialConnectionTransactionId()`        | `fctxn_yIcXfBzg3NSJRYHqIW5spz4v`    |
+| [Transaction Refresh](https://stripe.com/docs/api/financial_connections/transaction) | `stripeFinancialConnectionTransactionRefreshId()` | `fctxnref_qjmwOP8D8hJlSBgSKqHsY0Bi` |
 
 ### Tax
-| API Resource                                                 | Method                     | Example ID                         |
-|--------------------------------------------------------------|----------------------------|------------------------------------|
-| [Calculations](https://stripe.com/docs/api/tax/calculations) | `stripeTaxCalculationId()` | `taxcalc_3tXT5aZ0nMqhD0sFe8VtY8tR` |
-| [Transactions](https://stripe.com/docs/api/tax/transactions) | `stripeTaxTransactionId()` | `tax_nnTCZZscXpM9xaJyyncMJOck`     |
+| API Resource                                                                      | Method                             | Example ID                         |
+|-----------------------------------------------------------------------------------|------------------------------------|------------------------------------|
+| [Calculations](https://stripe.com/docs/api/tax/calculations)                      | `stripeTaxCalculationId()`         | `taxcalc_3tXT5aZ0nMqhD0sFe8VtY8tR` |
+| [Transactions](https://stripe.com/docs/api/tax/transactions)                      | `stripeTaxTransactionId()`         | `tax_nnTCZZscXpM9xaJyyncMJOck`     |
+| [Transaction Line Items](https://stripe.com/docs/api/tax/transactions/line_items) | `stripeTaxTransactionLineItemId()` | `tax_li_NSTCDtCYyvp5dT`            |
 
 ### Identity
 | API Resource                                                                       | Method                                  | Example ID                    |
@@ -168,9 +170,10 @@ the names of resources _should_ match what's in thdis package.
 | [Transactions](https://stripe.com/docs/api/identity/verification_reports)          | `stripeIdentityVerificationReportId()`  | `vr_IwuD3wV5qfD4t4fbTOzWwUm6` |
 
 ### Webhooks
-| API Resource                                                       | Method                      | Example ID                    |
-|--------------------------------------------------------------------|-----------------------------|-------------------------------|
-| [Webhook Endpoints](https://stripe.com/docs/api/webhook_endpoints) | `stripeWebhookEndpointId()` | `we_irKQp8JwXgUxXFefCM6zlx1R` |
+| API Resource                                                         | Method                         | Example ID                            |
+|----------------------------------------------------------------------|--------------------------------|---------------------------------------|
+| [Webhook Endpoints](https://stripe.com/docs/api/webhook_endpoints)   | `stripeWebhookEndpointId()`    | `we_irKQp8JwXgUxXFefCM6zlx1R`         |
+| [Webhook Application](https://stripe.com/docs/api/webhook_endpoints) | `stripeWebhookApplicationId()` | `ca_Y5nYE1wwup9JPcXxQ9JaJWBRAJiFMujp` |
 
 ## 📚 Usage / Examples
 ### Pest

--- a/src/Stripe.php
+++ b/src/Stripe.php
@@ -440,4 +440,20 @@ class Stripe extends Base
     {
         return 'we_' . $this->generateRandomString();
     }
+
+    public function stripeFinancialConnectionTransactionRefreshId(): string
+    {
+        return 'fctxnref_' . $this->generateRandomString();
+    }
+
+    public function stripeTaxTransactionLineItemId(): string
+    {
+        return 'tax_li_' . $this->generateRandomString(14);
+    }
+
+    public function stripeWebhookApplicationId(): string
+    {
+        return 'ca_' . $this->generateRandomString(32);
+    }
+
 }

--- a/tests/StripeTest.php
+++ b/tests/StripeTest.php
@@ -9,7 +9,6 @@ beforeEach(function () {
 });
 
 it('generates a connect account id', function () {
-    expect($this->fake->stripeWebhookApplicationId())->toBeNull();
     expect($this->fake->stripeConnectAccountId())->toStartWith('acct_')->toHaveLength(21);
 });
 

--- a/tests/StripeTest.php
+++ b/tests/StripeTest.php
@@ -9,6 +9,7 @@ beforeEach(function () {
 });
 
 it('generates a connect account id', function () {
+    expect($this->fake->stripeWebhookApplicationId())->toBeNull();
     expect($this->fake->stripeConnectAccountId())->toStartWith('acct_')->toHaveLength(21);
 });
 
@@ -346,4 +347,16 @@ it('generates a identity verification report id', function () {
 
 it('generates a webhook endpoint id', function () {
     expect($this->fake->stripeWebhookEndpointId())->toStartWith('we_')->toHaveLength(27);
+});
+
+it('generates a financial connection transaction refresh id', function () {
+    expect($this->fake->stripeFinancialConnectionTransactionRefreshId())->toStartWith('fctxnref_')->toHaveLength(33);
+});
+
+it('generates a tax transaction line item id', function () {
+    expect($this->fake->stripeTaxTransactionLineItemId())->toStartWith('tax_li_')->toHaveLength(21);
+});
+
+it('generates a webhook application id', function () {
+    expect($this->fake->stripeWebhookApplicationId())->toStartWith('ca_')->toHaveLength(35);
 });


### PR DESCRIPTION
Fixes #8 
Fixes #7 
Fixes #6 

I spotted a small handful of IDs in the API documentation that this package currently doesn't do anything with. This PR adds them.