### PR TITLE
change tax code generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ the names of resources _should_ match what's in this package.
 | [Prices](https://stripe.com/docs/api/prices)                   | `stripeProductPriceId()`         | `price_YhlhAgy0lHbLcOWwFZ596x1S` |
 | [Promotion Codes](https://stripe.com/docs/api/promotion_codes) | `stripeProductPromotionCodeId()` | `promo_7ADzsJ6WuQIsKsIj4T4MTeIX` |
 | [Discounts](https://stripe.com/docs/api/discounts)             | `stripeProductDiscountId()`      | `di_DleWj1FqYhsriqRSaQr6jCgs`    |
-| [Tax Codes](https://stripe.com/docs/api/tax_codes)             | `stripeProductTaxCodeId()`       | `txcd_zXWfi0FF`                  |
+| [Tax Codes](https://stripe.com/docs/api/tax_codes)             | `stripeProductTaxCodeId()`       | `txcd_90766505`                  |
 | [Tax Rates](https://stripe.com/docs/api/tax_rates)             | `stripeProductTaxRateId()`       | `txr_nNePe3bTkOwlrAbsAxpXzWXy`   |
 | [Shipping Rates](https://stripe.com/docs/api/shipping_rates)   | `stripeProductShippingRateId()`  | `shr_Sg2ZpoUCsfdAujoCc8U8MDba`   |
 

--- a/src/Stripe.php
+++ b/src/Stripe.php
@@ -4,9 +4,14 @@ namespace Faker\Provider;
 
 class Stripe extends Base
 {
-    private function generateRandomString($length = 24): string
+    private function generateRandomString($length = 24, $numericOnly = false): string
     {
-        $characters = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
+        if ($numericOnly) {
+            $characters = '0123456789';
+        } else {
+            $characters = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
+        }
+
         $string = '';
         $max = strlen($characters) - 1;
 
@@ -144,7 +149,7 @@ class Stripe extends Base
 
     public function stripeProductTaxCodeId(): string
     {
-        return 'txcd_' . $this->generateRandomString(8);
+        return 'txcd_' . $this->generateRandomString(8, true);
     }
 
     public function stripeProductTaxRateId(): string


### PR DESCRIPTION
Stripe Tax codes are 8 digits, prefixed with `txcd_`. 

Previously, we were generating 8 alpha numeric characters. This PR updates that function to generate numbers only, to make it match closer to what Stripe generates.