### PR TITLE
add support for crypto onramp sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,12 @@ the names of resources _should_ match what's in this package.
 | [VerificationSessions](https://stripe.com/docs/api/identity/verification_sessions) | `stripeIdentityVerificationSessionId()` | `vs_j8AvYT7Tbmjz26tASmjdcyNt` |
 | [Transactions](https://stripe.com/docs/api/identity/verification_reports)          | `stripeIdentityVerificationReportId()`  | `vr_IwuD3wV5qfD4t4fbTOzWwUm6` |
 
+### Crypto
+| API Resource                                                          | Method                          | Example ID                     |
+|-----------------------------------------------------------------------|---------------------------------|--------------------------------|
+| [Onramp Sessions](https://stripe.com/docs/api/crypto/onramp_sessions) | `stripeCryptoOnrampSessionId()` | `cos_wlo5PYZC2j8lFHnMaxbuFBK8` |
+
+
 ### Webhooks
 | API Resource                                                         | Method                         | Example ID                            |
 |----------------------------------------------------------------------|--------------------------------|---------------------------------------|

--- a/src/Stripe.php
+++ b/src/Stripe.php
@@ -461,4 +461,8 @@ class Stripe extends Base
         return 'ca_' . $this->generateRandomString(32);
     }
 
+    public function stripeCryptoOnrampSessionId(): string
+    {
+        return 'cos_' . $this->generateRandomString();
+    }
 }

--- a/tests/StripeTest.php
+++ b/tests/StripeTest.php
@@ -361,5 +361,5 @@ it('generates a webhook application id', function () {
 });
 
 it('generates a crypto onramp session id', function () {
-    expect($this->fake->stripeCryptoOnrampSessionId())->toStartWith('cdos_')->toHaveLength(28);
+    expect($this->fake->stripeCryptoOnrampSessionId())->toStartWith('cos_')->toHaveLength(28);
 });

--- a/tests/StripeTest.php
+++ b/tests/StripeTest.php
@@ -359,3 +359,7 @@ it('generates a tax transaction line item id', function () {
 it('generates a webhook application id', function () {
     expect($this->fake->stripeWebhookApplicationId())->toStartWith('ca_')->toHaveLength(35);
 });
+
+it('generates a crypto onramp session id', function () {
+    expect($this->fake->stripeCryptoOnrampSessionId())->toStartWith('cdos_')->toHaveLength(28);
+});


### PR DESCRIPTION
Stripe have recently added [Crypto Onramp Sessions](https://stripe.com/docs/api/crypto/onramp_sessions) to their API docs and whilst this feature is marked as a "Preview feature", I figured I'd add support for it to this package. I will, however, keep an eye on the docs and if it gets removed from there, I will remove it from this package to keep it up to date with what Stripe offer. 