### PR TITLE
generate capability id

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ the names of resources _should_ match what's in this package.
 | [Accounts](https://stripe.com/docs/api/accounts)                     | `stripeConnectAccountId()`              | `acct_l8cMrvSDcUT4qP2h`              |
 | [Application Fees](https://stripe.com/docs/api/application_fees)     | `stripeConnectApplicationFeeId()`       | `fee_ITNGc4r7B4QMjtOjsLr1GA2U`       |
 | [Application Fee Refunds](https://stripe.com/docs/api/fee_refunds)   | `stripeConnectApplicationFeeRefundId()` | `fr_XxY71TOJinzdNkmEQUVtlUGk`        |
+| [Capabilities](https://stripe.com/docs/api/capabilities)             | `stripeConnectCapabilityId()`           | `acap_gettfmKTrHMdUQgppBj8BJ6F`      |
 | [External Accounts](https://stripe.com/docs/api/external_accounts)   | `stripeConnectExternalAccountId()`      | `ba_j8048CaKvbk1ie7lfxyzXF19`        |
 | [Persons](https://stripe.com/docs/api/persons)                       | `stripeConnectPersonId()`               | `person_cNquFb7JU2nVsfIlprJHqIc1`    |
 | [Top-ups](https://stripe.com/docs/api/topups)                        | `stripeConnectTopUpId()`                | `tu_kdxjWmOqbz9J5rMdnibcnr37`        |

--- a/src/Stripe.php
+++ b/src/Stripe.php
@@ -475,4 +475,9 @@ class Stripe extends Base
     {
         return 'cos_' . $this->generateRandomString() . '_secret_' .  $this->generateRandomString(35);
     }
+
+    public function stripeConnectCapabilityId(): string
+    {
+        return 'acap_' . $this->generateRandomString();
+    }
 }

--- a/tests/StripeTest.php
+++ b/tests/StripeTest.php
@@ -371,3 +371,7 @@ it('generates a payment intent client secret', function () {
 it('generates a crypto onramp session client secret', function () {
     expect($this->fake->stripeCryptoOnrampSessionClientSecret())->toStartWith('cos_')->toContain('_secret_')->toHaveLength(71)->toBeString();
 })->repeat(2);
+
+it('generates a connect capability id', function () {
+    expect($this->fake->stripeConnectCapabilityId())->toStartWith('acap_')->toHaveLength(29)->toBeString();
+})->repeat(2);


### PR DESCRIPTION
Adds support for Stripe [Account Capabilities](https://stripe.com/docs/api/capabilities) and will generate a random 29 character ID, prefixes with `acap_`.