### PR TITLE
add issuing tokens id

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ the names of resources _should_ match what's in this package.
 | [Cardholders](https://stripe.com/docs/api/issuing/cardholders)       | `stripeIssuingCardholderId()`    | `ich_EyqQ6EcYkhzgyrGEQSCY68EB`   |
 | [Cards](https://stripe.com/docs/api/issuing/cards)                   | `stripeIssuingCardId()`          | `ic_IsXAmEVzInXUPtq4uttDZ2g2`    |
 | [Disputes](https://stripe.com/docs/api/issuing/disputes)             | `stripeIssuingDisputeId()`       | `idp_lXR4WsU6fhdpErzWVNOr24Ux`   |
+| [Tokens](https://stripe.com/docs/api/issuing/tokens)                 | `stripeIssuingTokenId()`   | `ipi_FqGAHy3JUvUsjWdqyaViRFm2`   |
 | [Transactions](https://stripe.com/docs/api/issuing/transactions)     | `stripeIssuingTransactionId()`   | `ipi_FqGAHy3JUvUsjWdqyaViRFm2`   |
 
 ### Terminal

--- a/src/Stripe.php
+++ b/src/Stripe.php
@@ -490,4 +490,9 @@ class Stripe extends Base
     {
         return 'fcinba_' . $this->generateRandomString();
     }
+
+    public function stripeIssuingTokenId(): string
+    {
+        return 'intok_' . $this->generateRandomString();
+    }
 }

--- a/tests/StripeTest.php
+++ b/tests/StripeTest.php
@@ -383,3 +383,7 @@ it('generates a cash balance transaction id', function () {
 it('generates a financial connection account inferred balance id', function () {
     expect($this->fake->stripeFinancialConnectionAccountInferredBalanceId())->toStartWith('fcinba_')->toHaveLength(31)->toBeString();
 })->repeat(2);
+
+it('generates a issuing token id', function () {
+    expect($this->fake->stripeIssuingTokenId())->toStartWith('intok_')->toHaveLength(30)->toBeString();
+})->repeat(2);


### PR DESCRIPTION
Adds the ability to use `stripeIssuingTokenId()` to generate a Issuing Token ID. 