### PR TITLE
remove `stripeFinancialConnectionAccountInferredBalanceId()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,6 @@ the names of resources _should_ match what's in this package.
 | API Resource                                                                                      | Method                                                | Example                             |
 |---------------------------------------------------------------------------------------------------|-------------------------------------------------------|-------------------------------------|
 | [Accounts](https://stripe.com/docs/api/financial_connections/accounts)                            | `stripeFinancialConnectionAccountId()`                | `fca_z3JzQ1OCkYved5uWOqh3b387`      |
-| [Accounts Inferred Balances](https://stripe.com/docs/api/financial_connections/inferred_balances) | `stripeFinancialConnectionAccountInferredBalanceId()` | `fcinba_egyG5XMYYLLXkadyiM7FEVRW`   |
 | [Account Ownership](https://stripe.com/docs/api/financial_connections/ownership)                  | `stripeFinancialConnectionAccountOwnershipId()`       | `fcaowns_XwyWHMQFo9koh9U1TuOMW43D`  |
 | [Sessions](https://stripe.com/docs/api/financial_connections/session)                             | `stripeFinancialConnectionSessionId()`                | `fcsess_ZnomHexUQ68qiad2GWqQsvsa`   |
 | [Transactions](https://stripe.com/docs/api/financial_connections/transaction)                     | `stripeFinancialConnectionTransactionId()`            | `fctxn_yIcXfBzg3NSJRYHqIW5spz4v`    |

--- a/src/Stripe.php
+++ b/src/Stripe.php
@@ -486,11 +486,6 @@ class Stripe extends Base
         return 'ccsbtxn_' . $this->generateRandomString();
     }
 
-    public function stripeFinancialConnectionAccountInferredBalanceId(): string
-    {
-        return 'fcinba_' . $this->generateRandomString();
-    }
-
     public function stripeIssuingTokenId(): string
     {
         return 'intok_' . $this->generateRandomString();

--- a/tests/StripeTest.php
+++ b/tests/StripeTest.php
@@ -380,10 +380,6 @@ it('generates a cash balance transaction id', function () {
     expect($this->fake->stripeCashBalanceTransactionId())->toStartWith('ccsbtxn_')->toHaveLength(32)->toBeString();
 })->repeat(2);
 
-it('generates a financial connection account inferred balance id', function () {
-    expect($this->fake->stripeFinancialConnectionAccountInferredBalanceId())->toStartWith('fcinba_')->toHaveLength(31)->toBeString();
-})->repeat(2);
-
 it('generates a issuing token id', function () {
     expect($this->fake->stripeIssuingTokenId())->toStartWith('intok_')->toHaveLength(30)->toBeString();
 })->repeat(2);


### PR DESCRIPTION
Removes `stripeFinancialConnectionAccountInferredBalanceId()` which was added in https://github.com/JonPurvis/faker-stripe/pull/17. Looks like Stripe no longer offer this as the docs link 404s. 